### PR TITLE
Deprecated Obj-C methods replaced.

### DIFF
--- a/Classes/tangoConnection.m
+++ b/Classes/tangoConnection.m
@@ -25,7 +25,9 @@
 		_password = [password copy];
 		_share = [share copy];
 		
-		_connection = tango_create([share cString], [username cString], [password cString]);
+		_connection = tango_create([share cStringUsingEncoding:NSUnicodeStringEncoding],
+                                   [username cStringUsingEncoding:NSUnicodeStringEncoding],
+                                   [password cStringUsingEncoding:NSUnicodeStringEncoding]);
 	}
 	return self;
 }
@@ -92,7 +94,8 @@
 }
 
 - (NSString *)errorMessage {
-	return [NSString stringWithCString:tango_error_message(_connection)];
+	return [NSString stringWithCString:tango_error_message(_connection)
+                              encoding:NSUnicodeStringEncoding];
 }
 
 


### PR DESCRIPTION
Removed deprecated Obj-c methods when casting a cstring to an NSString and visa versa. Set encoding to be unicode.
